### PR TITLE
Dotenv 연결에서 발생한 이슈 해결

### DIFF
--- a/src/apis/utils/instance.tsx
+++ b/src/apis/utils/instance.tsx
@@ -1,9 +1,6 @@
 import axios from 'axios';
-import dotenv from 'dotenv';
 
-dotenv.config();
-
-const BASE_URL = `http://${process.env.SERVER_URL}:${process.env.SERVER_PORT}/`;
+const BASE_URL = `http://${import.meta.env.VITE_SERVER_URL}:${import.meta.env.VITE_SERVER_PORT}/`;
 // const BASE_URL = `http://localhost:8080/`;
 
 const defaultApi = axios.create({
@@ -30,7 +27,7 @@ authApi.interceptors.request.use(config => {
 });
 
 const authFileApi = axios.create({
-  // baseURL: BASE_URL,
+  baseURL: BASE_URL,
   headers: { 'Content-Type': 'multipart/form-data; charset: UTF-8;' },
 });
 


### PR DESCRIPTION
### #️⃣ Issue Number

- close #39 

### ✏️Task

- [ ]  Dotenv 연결 중에 발생한 이슈 해결

### ✏️Tasks Description

# ⚠️ 수정

`VITE + React + TS`로 생성한 프로젝트에서 `process is not defined error` 문제가 발생하였다.

<img width="510" alt="스크린샷 2024-07-28 오후 11 27 55" src="https://github.com/user-attachments/assets/d0510dae-e790-4414-a1fd-d72ffc8a838b">


## 📍 원인

`VITE + React + TS`에서는 `proces` 대신 `import.meta.env`를 사용해 .env 환경 변수를 가져오기 때문.

그렇기 때문에 기존의 내용은 제거하고 다음과 같이 사용한다.

```scss
const BASE_URL = `http://${import.meta.env.VITE_SERVER_URL}:${import.meta.env.VITE_SERVER_PORT}/`;
```

여기서 접두사로 VITE_를 붙이는 이유는
Vite에서 접근 가능한 환경 변수는 일반 환경 변수와 구분을 위해 VITE_ 라는 접두사를 붙여 나타내기 때문이다.

변경된 .env 파일의 내용은 `노션`을 참고한다.

예시)

```tsx
// .env
VITE_APP_GA_TRACKING_ID=yourId
DB_PASSWD=1234

// .ts
const gaTrackingId = import.meta.env.VITE_APP_GA_TRACKING_ID;
console.log(gaTrackingId); // yourId

const dbPasswd = import.meta.env.DB_PASSWD;
console.log(dbPasswd); // undefined
```

이렇게 지정한 경우

```scss
import dotenv from 'dotenv';

dotenv.config();
```

를 사용하지 않아도 된다.

### 🗓Next Task

- [ ] x
